### PR TITLE
Add command line interface application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,32 @@
+sudo: false
 language: php
-
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: 7.0
-    
-before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction
+  include:
+    - php: 5.4
+      env:
+      - REPORT_COVERAGE=true
+    - php: 5.5
+    - php: 5.6
+    - php: 7
+    - php: hhvm
+      env:
+
+cache:
+  directories:
+  - $HOME/.composer/cache
+  - vendor
+
+before_install:
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' && $TRAVIS_PHP_VERSION != "hhvm"  ]]; then phpenv config-rm xdebug.ini ; fi
+  - travis_retry composer self-update
+
+install:
+  - travis_retry composer install --no-interaction
 
 script:
-  - phpunit
+  - composer test
 
 after_script:
-  - php vendor/bin/coveralls -v
+  - if [[ $REPORT_COVERAGE == 'true' ]]; then composer coverage ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
-      env:
-      - REPORT_COVERAGE=true
-    - php: 5.5
-    - php: 5.6
-    - php: 7
-    - php: hhvm
-      env:
+  - php: 5.5
+    env:
+    - REPORT_COVERAGE=true
+  - php: 5.6
+  - php: 7
+  - php: hhvm
+  allow_failures:
+  - php: hhvm
 
 cache:
   directories:
@@ -19,7 +19,7 @@ cache:
   - vendor
 
 before_install:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' && $TRAVIS_PHP_VERSION != "hhvm"  ]]; then phpenv config-rm xdebug.ini ; fi
+  - if [[ $REPORT_COVERAGE != 'true' && $TRAVIS_PHP_VERSION != "hhvm"  ]]; then phpenv config-rm xdebug.ini ; fi
   - travis_retry composer self-update
 
 install:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A small CLI application is also delivered in `/bin/haikunator`.
 
 Use as follows:
 
-```shell
+```text
 $: ./bin/haikunator help generate
 Haikunator, version dev-master
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ Haikunator::$NOUNS
 ```
 *If ```tokenHex``` is true, it overrides any tokens specified in ```tokenChars```*
 
+## Command Line Interface
+
+A small CLI application is also delivered in `/bin/haikunator`.
+
+Use as follows:
+
+```shell
+$: ./bin/haikunator help generate
+Haikunator, version dev-master
+
+Usage:
+ generate [--token-length=] [--token-chars=] [--token-hex|-x] [--delimiter=] [--nouns=] [--adjectives=]
+
+Arguments:
+ --token-length        An integer representing the length of the token; defaults to 4
+ --token-chars         The characters to use for the token; defaults to numbers
+ --token-hex|-x        Same as --token-chars=0123456789abcdef
+ --delimiter           The delimiter for all the part of the result; defaults to '-'
+ --nouns|--adjectives  A list of words separated by commas, or a text filename
+                       containing words separated by commas, spaces or new lines
+
+Help:
+
+Generate Heroku-like random names
+```
+
+To execute it simply via the `haikunator` command in you system, you can install it globally via Composer with `composer global require atrox/haikunator` and then ensure your `~/.composer/vendor/bin` is present in your env's `$PATH`. 
+
 ## Contributing
 
 Everyone is encouraged to help improve this project. Here are a few ways you can help:

--- a/bin/haikunator
+++ b/bin/haikunator
@@ -1,8 +1,8 @@
 #!/usr/bin/env php
 <?php
 
-if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-    fwrite(STDERR, "PHP minimum version required is 5.4.0, current is ".PHP_VERSION.PHP_EOL);
+if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+    fwrite(STDERR, "PHP minimum version required is 5.5.0, current is ".PHP_VERSION.PHP_EOL);
     exit(1);
 }
 

--- a/bin/haikunator
+++ b/bin/haikunator
@@ -33,7 +33,9 @@ $application = new Console\Application(
                 '--token-chars'  => 'The characters to use for the token; defaults to numbers',
                 '--token-hex|-x' => 'Same as --token-chars=0123456789abcdef',
                 '--delimiter'    => "The delimiter for all the part of the result; defaults to '-'",
-                '--nouns|--adjectives' => 'A list of words separated by commas, or a text filename containing words separated by commas, spaces or new lines',
+                '--nouns|--adjectives' =>
+                    "A list of words separated by commas, or a text filename
+                       containing words separated by commas, spaces or new lines",
             ],
             'filters' => [
                 'token-hex'    => new Filter\Boolean(),

--- a/bin/haikunator
+++ b/bin/haikunator
@@ -1,0 +1,54 @@
+#!/usr/bin/env php
+<?php
+
+if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+    fwrite(STDERR, "PHP minimum version required is 5.4.0, current is ".PHP_VERSION.PHP_EOL);
+    exit(1);
+}
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Zend\Filter;
+use Zend\Validator;
+use ZF\Console;
+
+$version = '@package_version@';
+
+// Reset version if not rewritten (which happens when using a phar)
+$version = ($version === '@' . 'package_version' . '@')
+    ? 'dev-master'
+    : $version;
+
+$application = new Console\Application(
+    'Haikunator',
+    $version,
+    [
+        [
+            'name'              => 'generate',
+            'route'             => '[--token-length=] [--token-chars=] [--token-hex|-x] [--delimiter=] [--nouns=] [--adjectives=]',
+            'description'       => 'Generate Heroku-like random names',
+            'short_description' => 'Generate Heroku-like random names',
+            'options_descriptions' => [
+                '--token-length' => 'An integer representing the length of the token; defaults to 4',
+                '--token-chars'  => 'The characters to use for the token; defaults to numbers',
+                '--token-hex|-x' => 'Same as --token-chars=0123456789abcdef',
+                '--delimiter'    => "The delimiter for all the part of the result; defaults to '-'",
+                '--nouns|--adjectives' => 'A list of words separated by commas, or a text filename containing words separated by commas, spaces or new lines',
+            ],
+            'filters' => [
+                'token-hex'    => new Filter\Boolean(),
+                'x'            => new Filter\Boolean(),
+                'token-chars'  => new Filter\StringTrim(),
+                'nouns'        => new Console\Filter\Explode(),
+                'adjectives'   => new Console\Filter\Explode(),
+            ],
+            'validators' => [
+                'token-length' => new Validator\Regex('/\d+/'),
+            ],
+            'handler' => new Atrox\HaikunatorCommand(),
+        ]
+    ]
+);
+
+$exit = $application->run();
+exit($exit);

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,32 @@
         }
     ],
     "minimum-stability": "stable",
-    "require": {},
+    "require": {
+      "php": ">=5.4",
+        "zfcampus/zf-console": "^1.2",
+        "zendframework/zend-filter": "^2.5",
+        "zendframework/zend-validator": "^2.5"
+    },
     "require-dev": {
       "phpunit/phpunit": "4.5.*",
       "phpunit/php-code-coverage": "2.2.*",
       "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
-      "classmap": [
-        "src/"
-      ]
+      "psr-4": {
+        "Atrox\\": "src"
+      }
+    },
+    "autoload-dev": {
+      "psr-4": {
+        "Atrox\\Test\\": "src"
+      }
+    },
+    "bin": [
+      "bin/haikunator"
+    ],
+    "scripts": {
+      "test": "vendor/bin/phpunit",
+      "coverage": "vendor/bin/coveralls -v"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-      "php": ">=5.4",
+      "php": ">=5.5",
         "zfcampus/zf-console": "^1.2",
         "zendframework/zend-filter": "^2.5",
         "zendframework/zend-validator": "^2.5"

--- a/src/Haikunator.php
+++ b/src/Haikunator.php
@@ -66,4 +66,14 @@ class Haikunator
         $sections = [$adjective, $noun, $token];
         return implode($params["delimiter"], array_filter($sections));
     }
+
+    /**
+     * @param array $params
+     *
+     * @return string
+     */
+    public function __invoke(array $params = [])
+    {
+        return static::haikunate($params);
+    }
 }

--- a/src/HaikunatorCommand.php
+++ b/src/HaikunatorCommand.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Atrox;
+
+use Zend\Console\Adapter\AdapterInterface as ConsoleAdapter;
+use ZF\Console\Route;
+
+class HaikunatorCommand
+{
+    /**
+     * @var Haikunator
+     */
+    protected $haikunator;
+
+    public function __construct(Haikunator $haikunator = null)
+    {
+        if (! $haikunator) {
+            $haikunator = new Haikunator();
+        }
+
+        $this->haikunator = $haikunator;
+    }
+
+
+    public function __invoke(Route $route, ConsoleAdapter $console)
+    {
+        $params = $this->getParamsFromRoute($route);
+        $params = $this->filterNullParams($params);
+
+        $this->setNounsFromRoute($route);
+        $this->setAdjectivesFromRoute($route);
+
+        $console->writeLine($this->haikunator->__invoke($params));
+    }
+
+    /**
+     * @param Route $route
+     *
+     * @return array
+     */
+    protected function getParamsFromRoute(Route $route)
+    {
+        $params = [
+            'tokenLength' => $route->getMatchedParam('token-length'),
+            'tokenHex'    => ($route->getMatchedParam('token-hex') || $route->getMatchedParam('x')) ?: null,
+            'tokenChars'  => $route->getMatchedParam('token-chars'),
+            'delimiter'   => $route->getMatchedParam('delimiter'),
+        ];
+
+        return $params;
+    }
+
+    /**
+     * @param $params
+     *
+     * @return array
+     */
+    protected function filterNullParams($params)
+    {
+        return array_filter($params, function ($value) {
+            return $value !== null;
+        });
+    }
+
+    /**
+     * @param Route $route
+     */
+    protected function setNounsFromRoute(Route $route)
+    {
+        $nouns      = $route->getMatchedParam('nouns');
+        if (! empty($nouns)) {
+            Haikunator::$NOUNS = $this->getValuesFromFileIfExists($nouns);
+        }
+    }
+
+    /**
+     * @param Route $route
+     */
+    protected function setAdjectivesFromRoute(Route $route)
+    {
+        $adjectives = $route->getMatchedParam('adjectives');
+        if (! empty($adjectives)) {
+            Haikunator::$ADJECTIVES = $this->getValuesFromFileIfExists($adjectives);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getValuesFromFileIfExists(array $values)
+    {
+        return count($values) === 1 && file_exists($values[0])
+            ? preg_split('/[\s,]+/', file_get_contents($values[0]))
+            : $values;
+    }
+}

--- a/tests/HaikunatorCommandTest.php
+++ b/tests/HaikunatorCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @license See the file LICENSE for copying permission
+ */
+
+namespace Atrox\Test;
+
+use Atrox\Haikunator;
+use Atrox\HaikunatorCommand;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Console\Adapter\AdapterInterface;
+use ZF\Console\Route;
+
+class HaikunatorCommandTest extends TestCase
+{
+    /**
+     * @var HaikunatorCommand
+     */
+    private $command;
+
+    /**
+     * @var Haikunator|MockObject
+     */
+    private $haikunator;
+
+    /**
+     * @var Route|MockObject
+     */
+    private $route;
+
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $console;
+
+    protected function setUp()
+    {
+        $this->haikunator = $this->getMock('Atrox\Haikunator');
+        $this->route      = $this->getMock('ZF\Console\Route', [], [], '', false);
+        $this->console    = $this->getMock('Zend\Console\Adapter\AdapterInterface');
+
+        $this->command = new HaikunatorCommand($this->haikunator);
+    }
+
+    public function testConstructorLazilyCreatesHaikunator()
+    {
+        $command = new HaikunatorCommand();
+
+        $propRefl = new \ReflectionProperty($command, 'haikunator');
+        $propRefl->setAccessible(true);
+        $this->assertInstanceOf('Atrox\Haikunator', $propRefl->getValue($command));
+    }
+
+    public function testFilterOutNullOptions()
+    {
+        $this->route->expects($this->any())->method('getMatchedParam')->willReturn(null);
+
+        $this->haikunator->expects($this->atLeastOnce())->method('__invoke')->with($this->isEmpty());
+
+        $this->command->__invoke($this->route, $this->console);
+    }
+
+    /**
+     * @param array $params
+     * @param array $expectedParams
+     *
+     * @dataProvider paramsDataProvider
+     */
+    public function testRouteParameters($params, array $expectedParams)
+    {
+        $map = [];
+        foreach ($params as $name => $value) {
+            $map[] = [ $name, null, $value ];
+        }
+        $this->route->expects($this->any())->method('getMatchedParam')->willReturnMap($map);
+
+        $this->haikunator->expects($this->atLeastOnce())->method('__invoke')->with($expectedParams);
+
+        $this->command->__invoke($this->route, $this->console);
+    }
+
+    public function paramsDataProvider()
+    {
+        return [
+            [ [ 'token-length' => 10 ], [ 'tokenLength' => 10 ] ],
+            [ [ 'token-hex' => true, 'x' => false ], [ 'tokenHex' => true ]],
+            [ [ 'token-hex' => false, 'x' => true ], [ 'tokenHex' => true ]],
+            [ [ 'token-hex' => false, 'x' => false ], [ ] ],
+            [ [ 'token-chars' => 'foobar' ], [ 'tokenChars' => 'foobar' ] ],
+            [ [ 'delimiter' => '.' ], [ 'delimiter' => '.' ] ],
+        ];
+    }
+
+    /**
+     * @dataProvider staticParamDataProvider
+     */
+    public function testStaticParams($name, array $value)
+    {
+        $map = [ [ $name, null, $value ] ];
+        $this->route->expects($this->any())->method('getMatchedParam')->willReturnMap($map);
+
+        $this->command->__invoke($this->route, $this->console);
+
+        $this->assertEquals($value, Haikunator::${strtoupper($name)});
+    }
+
+    public function staticParamDataProvider()
+    {
+        return [
+            [ 'nouns',  ['foo', 'bar', 'baz'] ],
+            [ 'adjectives',  ['foo', 'bar', 'baz'] ],
+        ];
+    }
+}

--- a/tests/HaikunatorCommandTest.php
+++ b/tests/HaikunatorCommandTest.php
@@ -36,9 +36,9 @@ class HaikunatorCommandTest extends TestCase
 
     protected function setUp()
     {
-        $this->haikunator = $this->getMock('Atrox\Haikunator');
-        $this->route      = $this->getMock('ZF\Console\Route', [], [], '', false);
-        $this->console    = $this->getMock('Zend\Console\Adapter\AdapterInterface');
+        $this->haikunator = $this->getMock(Haikunator::class);
+        $this->route      = $this->getMock(Route::class, [], [], '', false);
+        $this->console    = $this->getMock(AdapterInterface::class);
 
         $this->command = new HaikunatorCommand($this->haikunator);
     }
@@ -49,7 +49,7 @@ class HaikunatorCommandTest extends TestCase
 
         $propRefl = new \ReflectionProperty($command, 'haikunator');
         $propRefl->setAccessible(true);
-        $this->assertInstanceOf('Atrox\Haikunator', $propRefl->getValue($command));
+        $this->assertInstanceOf(Haikunator::class, $propRefl->getValue($command));
     }
 
     public function testFilterOutNullOptions()

--- a/tests/HaikunatorTest.php
+++ b/tests/HaikunatorTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Atrox\Haikunator;
+namespace Atrox\Test;
 
-class HaikunatorTest extends PHPUnit_Framework_TestCase
+use Atrox\Haikunator;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class HaikunatorTest extends TestCase
 {
 
     public function testDefaultUse()
@@ -86,4 +89,13 @@ class HaikunatorTest extends PHPUnit_Framework_TestCase
         $this->assertRegExp("/(green)(\\.)(reindeer)(\\.)(llllllll)$/i", $haikunate);
     }
 
+    public function testCanBeUsedAsCallable()
+    {
+        Haikunator::$ADJECTIVES = ['green'];
+        Haikunator::$NOUNS = ['reindeer'];
+        $haikunator = new Haikunator();
+        $this->assertTrue(is_callable($haikunator));
+        $params = [ 'tokenLength' => 0 ];
+        $this->assertSame($haikunator($params), Haikunator::haikunate($params));
+    }
 }


### PR DESCRIPTION
This PR adds a small CLI app made with `ZF\Console`.

``` text
$: ./bin/haikunator help generate
Haikunator, version dev-master

Usage:
 generate [--token-length=] [--token-chars=] [--token-hex|-x] [--delimiter=] [--nouns=] [--adjectives=]

Arguments:
 --token-length        An integer representing the length of the token; defaults to 4
 --token-chars         The characters to use for the token; defaults to numbers
 --token-hex|-x        Same as --token-chars=0123456789abcdef
 --delimiter           The delimiter for all the part of the result; defaults to '-'
 --nouns|--adjectives  A list of words separated by commas, or a text filename
                       containing words separated by commas, spaces or new lines

Help:

Generate Heroku-like random names
```

Incidentally, these general changes are also brought:
- make the main class `Haikunator` a callable by implementing a non static `__invoke()` method.
- add the `composer test` and `composer coverage` aliases to execute the respective dev tools.
- overhaul of the travis setup to use docker containers and other tweaks to speed up the builds
- bump the minimum PHP version to 5.5, as it was a requirement for the new dependencies, and 5.4 is EOL anyway. 
