### PR TITLE
Eliminate duplicate nouns and add unit tests to check for this issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### General ###
 /build/
+.idea/
 
 ### Composer ###
 composer.phar

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": ">=5.5"
+    "php": ">=7.2"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=5.0"
+    "phpunit/phpunit": ">=7.2"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="true">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Haikunator Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/Haikunator.php
+++ b/src/Haikunator.php
@@ -40,9 +40,9 @@ class Haikunator
         "mode", "moon", "morning", "mountain", "mouse", "mud", "night", "paper",
         "pine", "poetry", "pond", "queen", "rain", "recipe", "resonance", "rice",
         "river", "salad", "scene", "sea", "shadow", "shape", "silence", "sky",
-        "smoke", "snow", "snowflake", "sound", "star", "sun", "sun", "sunset",
+        "smoke", "snow", "snowflake", "sound", "star", "sun", "sunset",
         "surf", "term", "thunder", "tooth", "tree", "truth", "union", "unit",
-        "violet", "voice", "water", "water", "waterfall", "wave", "wildflower", "wind",
+        "violet", "voice", "water", "waterfall", "wave", "wildflower", "wind",
         "wood",
     ];
 

--- a/tests/HaikunatorTest.php
+++ b/tests/HaikunatorTest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\TestCase;
 class HaikunatorTest extends TestCase
 {
     private $nouns = [];
-
     private $adjectives = [];
 
     protected function setUp(): void

--- a/tests/HaikunatorTest.php
+++ b/tests/HaikunatorTest.php
@@ -12,6 +12,26 @@ use PHPUnit\Framework\TestCase;
  */
 class HaikunatorTest extends TestCase
 {
+    private $nouns = [];
+
+    private $adjectives = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nouns = Haikunator::$NOUNS;
+        $this->adjectives = Haikunator::$ADJECTIVES;
+    }
+
+    protected function tearDown(): void
+    {
+        Haikunator::$NOUNS = $this->nouns;
+        Haikunator::$ADJECTIVES = $this->adjectives;
+
+        parent::tearDown();
+    }
+
     /**
      * @param array $params
      * @param       $regex

--- a/tests/HaikunatorTest.php
+++ b/tests/HaikunatorTest.php
@@ -71,6 +71,18 @@ class HaikunatorTest extends TestCase
         $this->assertMatchesRegularExpression("/(red)(-)(reindeer)(-)(\\d{4})$/i", $haikunate);
     }
 
+    public function testNounsMustNotContainDuplicates()
+    {
+        $nouns = Haikunator::$NOUNS;
+        $this->assertEquals(count($nouns), count(array_flip($nouns)));
+    }
+
+    public function testAdjectivesMustNotContainDuplicates()
+    {
+        $adjectives = Haikunator::$ADJECTIVES;
+        $this->assertEquals(count($adjectives), count(array_flip($adjectives)));
+    }
+
     public function testEverythingInOne()
     {
         Haikunator::$ADJECTIVES = ['green'];


### PR DESCRIPTION
I have removed duplicate nouns 'sun' and 'water'. I have also added unit tests to prevent this from happening again. In addition, I have removed the obsolete option 'syntaxCheck' from `phpunit.xml`.

On top of that, I have updated the minimum version to the last (only just) supported version, which at this time is 7.2. 